### PR TITLE
Revert "feat(helm): update chart immich to 0.9.1"

### DIFF
--- a/flux/academy/immich/immich/app/helmrelease.yaml
+++ b/flux/academy/immich/immich/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: immich
-      version: 0.9.1
+      version: 0.8.5
       sourceRef:
         kind: HelmRepository
         name: immich


### PR DESCRIPTION
Reverts jonathanchancey/stacks#106
Helm upgrade failed for release immich/immich with chart immich@0.9.1: execution error at (immich/templates/checks.yaml:5:7): The postgres subchart is  │
│ deprecated. Please see https://github.com/immich-app/immich-charts/issues/149 for more detail.